### PR TITLE
6: Package and Module renamed to fit Regulations; Dockerfile adjusted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.7
+ARG PYTHON_VERSION=3.7
+FROM python:${PYTHON_VERSION}
 
 USER root
 RUN apt-get --quiet --assume-yes update && apt-get --quiet --assume-yes install sqlite3

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
-#! /usr/bin/env python2.7
+#! /usr/bin/env python
 import glob
 import os
 import sys
 
-from setuptools import setup, find_packages
-from datetime import datetime
+from setuptools import setup
+from setuptools import find_packages
 
-__version="11.0.1"
+__version = "11.0.2"
 
 def list_recursive(app, directory, extension="*"):
     """
@@ -22,25 +22,28 @@ def list_recursive(app, directory, extension="*"):
 
 included_packages = find_packages()
 
-setup(name="oc_portal_commons",
-      version=__version,
-      description="Common code, static files, settings and testing tools used at all portal variants",
-      long_description="",
-      long_description_content_type="text/plain",
-      install_requires=[
-          "oc-delivery-apps >= 11.2.8",
-          "packaging",
-          "pyparsing == 2.4.0",
-          "django-jquery", 
-          "django-tests",
-          "django-filter",
-          "fs",
-          "mock"
-      ],
-      packages=included_packages,
-      package_data={
-          "oc_portal_commons": (list_recursive("oc_portal_commons", "templates")
-                             + list_recursive("oc_portal_commons", "static")),
-      },
-      test_suite="oc_portal_commons.test.runtests.execute_test_suite",
-      )
+# notes:
+# 1. "mock" is a part of Python "unittest" (comes with interpreter since 3.6), removed from dependencies
+# 2. Python 2.7 is now obsolete since "oc-delivery-apps" has no support for it (comes from Django 3)
+
+spec = {
+        "name": "oc-portal-commons",
+        "version": __version,
+        "description": "Common code, static files, settings and testing tools used at all portal variants",
+        "long_description": "",
+        "long_description_content_type": "text/plain",
+        "install_requires": [
+            "oc-delivery-apps >=  11.2.8",
+            "packaging",
+            "pyparsing == 2.4.0",
+            "django-jquery",
+            "django-tests",
+            "django-filter",
+            "fs"],
+        "packages": included_packages,
+        "package_data": {
+            "oc_portal_commons": list_recursive("oc_portal_commons", "templates")
+                             + list_recursive("oc_portal_commons", "static")},
+        "python_requires": ">=3.6"}
+
+setup(**spec)


### PR DESCRIPTION
- *Package* renamed to fit Regulations (*oc-portal-commons*). Module name is OK already.
- Dockerfile adjusted to make possible to build for different Python-s (*ARG PYTHON_VERSION*)
- Obsolete dependencies removed from *setup.py*
- *python_requires* added to *setup.py*